### PR TITLE
Resolve migration directory relative to config path.

### DIFF
--- a/config.lisp
+++ b/config.lisp
@@ -53,7 +53,7 @@
       (string
        (first migration-conf))
       (keyword
-       (when (eql (first migration-conf) :realtive)
+       (when (eql (first migration-conf) :relative)
          (namestring
           (merge-pathnames (second migration-conf)
                            (make-pathname :name nil

--- a/config.lisp
+++ b/config.lisp
@@ -71,7 +71,8 @@
 				    (find-package '#:cl-migrations)))
 		(second (first specs)))
 	  (setf *migration-dir* (resolve-migration-dir specs))
-	  (unless (equal (subseq *migration-dir* (1- (length *migration-dir*))) "/")
+	  (unless (or (null *migration-dir*)
+                      (equal (subseq *migration-dir* (1- (length *migration-dir*))) "/"))
 	    ;;Looks like the user forgot add a trailing slash - fix this.
 	    (setf *migration-dir* (concatenate 'string *migration-dir* "/")))
 	  (format t "~%Setting up migrations directory: ~S" *migration-dir*)

--- a/migrate.lisp
+++ b/migrate.lisp
@@ -65,10 +65,11 @@
   "Get the version of latest migration available."
   (let ((files-list (get-migration-files))
 	(counter 0))
-    (dolist (file files-list counter)
-      (unless (equal (incf counter) (get-migration-number file))
-	(warn "Migration #~S is missing!" counter)
-	(return)))))
+    (unless (eql files-list :skipped)
+      (dolist (file files-list counter)
+        (unless (equal (incf counter) (get-migration-number file))
+          (warn "Migration #~S is missing!" counter)
+          (return))))))
 	 
 (defun generate (name)
   "Generate an empty migration file with an assigned version number."


### PR DESCRIPTION
Add configuration option to express that the migration directory
should be taken relatively to the configuration file path. This enables a per-project config file all project members can share without the need to adjust paths.

### Example

Given this directory structure:
```
db
├── migration.conf
└── migrations
    └── 1-create-users-table.lisp
```

You can set the contents of `migration.conf` to 

```lisp
((:sqlite3 ("test.db"))
 (:migration-dir (:realtive "migrations/")))
```

This configuration file indicates that a directory `migrations` relative to the location of `migration.conf` should be used to store migrations scripts. To make this work you have to tell `cl-migrations` where to find the migration configuration, like so:

```lisp
(setf cl-migrations:*config-pathname* #p"~/path/to/project/db/migration.conf")
```
     
