### PR TITLE
Generate migration files with time stamp prefix.

### DIFF
--- a/config.lisp
+++ b/config.lisp
@@ -112,7 +112,7 @@
       (format t "~%Schema table exists.")
       (progn 
 	(format t "~%Schema table doesn't exist, creating.")
-	(create-table *schema-table-name* '((version integer)))
+	(create-table *schema-table-name* '((version (varchar 500))))
 	;;Initialize the version number to 0.
 	(insert-records :into *schema-table-name*
 			:attributes '(version)


### PR DESCRIPTION
- Store latest version as string.

  Because the versions are actually timestamps, we overflow integer
  with 20170412114522.

- Use a time stamp to prefix migration scripts.

  This is more robust (especially when using a feature branch
  workflow) than using sequential prefix numbers.

Resolves #2.